### PR TITLE
Add a troubleshooting item for setting the right locale

### DIFF
--- a/docs/developers/compiling/ubuntu.md
+++ b/docs/developers/compiling/ubuntu.md
@@ -128,4 +128,7 @@ Error: GLSL 3.00 is not supported.  Supported versions are: 1.10, 1.20, 1.30, 1.
  - Enter the following line in the terminal before running, or add this to `~/.bashrc` or `~/.profile`:
  `export MESA_GL_VERSION_OVERRIDE=4.3`
  
+Set a number format on your system that uses the dot as decimal separator. Otherwise you might see errors like this from OpenGL complaining about invalid numbers, e.g. `error: syntax error, unexpected INTCONSTANT, expecting IDENTIFIER or TYPE_IDENTIFIER or NEW_IDENTIFIER`.
+ - Before launching, set the system locale to `en_US` or similar: `export LC_NUMERIC="en_US.UTF-8"` 
+ 
 It may be necessary to install boost if trying to build some of the older branches.


### PR DESCRIPTION
If the system uses a locale with the comma as decimal separator (in my case German), the compile goes fine but when launching, OpenGL errors will pop up for all planets and only the atmospheres are visible.

This behavior has been described in [issue 1442 on the OpenSpace repo](https://github.com/OpenSpace/OpenSpace/issues/1442) but since the issue is quite hard to find and also doesn't result in the same error messages as with v16.0, I thought it would be good to point this out to everyone compiling on Ubuntu. Maybe it would make sense to also copy this to the compile guide for fedora?