### PR TITLE
Rewrite Server Installation page

### DIFF
--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -7,58 +7,96 @@ parent: WMS
 nav_order: 1
 ---
 
-This wiki covers the steps required to get an OpenSpace WMS (Web Map Server) configured & running.  This serves MRF (Meta Raster Format) files.  Another name for this service is AHTSE (An Httpd/apache Tile-Serving Engine).
-[This wiki](server-import) covers the steps involved in importing WMS dataset(s) so that the AHTSE can serve tiles from the set.  [This wiki](server-conversion) covers the steps involved in converting a raw raster image into the MRF format.
+This wiki covers the steps required to get an OpenSpace WMS (Web Map Server) configured & running. This serves MRF (Meta Raster Format) files. Another name for this service is AHTSE (An Httpd/Apache Tile-Serving Engine).
+[This wiki](server-import) covers the steps involved in importing WMS dataset(s) so that the AHTSE can serve tiles from the set. [This wiki](server-conversion) covers the steps involved in converting a raw raster image into the MRF format.
 
-These instructions are specific to a Linux server install.
+These instructions are specific to a Ubuntu Linux 22.04 server install. However other Linux distributions can work with some packages or paths changed around.
 
 ## Web Server Setup
 
-Install the following software via the Operating System's package installer.
-1. Apache2 web server (version 2.4.23 or higher is required).
-2. Apache2 header files (this might be in the form of a **dev**elopment install apckage.
-3. GDAL (version 2.2 or higher is recommended). Install packages **gdal-bin** and **gdal-dev**.
-4. git
+Install the following software for getting AHTSE up and running:
 
-Install the five MRF modules (**mrf**, **receivef**, **sfim**, **reproject**, **convert**), which run as modules in the Apache web server.  For each module, it is necessary to download the source code, compile the module, and configure Apache to run the module.  The steps are similar for all modules, so instructions are given first for the **mod_mrf** module, and then any differing or specific information is provided for the others in subsequent sections.
+- Apache web server (`apache2`)
+- Apache web server developer headers (`apache2-dev`)
+- Geospatial Data Abstraction Library (GDAL) (`gdal-bin`)
+- GDAL developer package (`libgdal-dev`)
+- Git (`git`)
+- Make (`build-essential`)
+- GNU C/C++ compilers (`g++`/`gcc`)
 
-## Obtain source code for all modules before building them
-Some, but not all, modules require include files from other modules or related libraries. So all necessary repositories will be cloned first before building any of them.
-1. Create a base directory in which all modules will be cloned (e.g. `mkdir ~/wms_modules`).
-2. `cd` into that directory
-3. Clone each of these repositories from the base directory (a subdirectory will automatically be created in the base directory for each repository): 
-* git clone https://github.com/lucianpls/libahtse.git
-* git clone https://github.com/lucianpls/AHTSE.git
-* git clone https://github.com/lucianpls/libicd.git
-* git clone https://github.com/lucianpls/mod_mrf.git
-* git clone https://github.com/lucianpls/mod_receive.git
-* git clone https://github.com/lucianpls/mod_sfim.git
-* git clone https://github.com/lucianpls/mod_reproject.git
-* git clone https://github.com/lucianpls/mod_convert.git
+For example on downloading this via Ubuntu 22.04 LTS:
 
-## Add the _mod_mrf_ module
-1. From the base directory, `cd mod_mrf/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
-2. Edit **Makefile.lcl**, find the line that defines **EXTRA_INCLUDES**, and add the following lines _below_ that line:
+```bash
+sudo apt install apache2 apache2-dev gdal-bin libgdal-dev build-essential gcc g++
 ```
+
+## Obtaining AHSTE dependencies
+
+Some, but not all, modules require include files from other modules or related libraries. So all necessary repositories will be cloned first before building any of them.
+
+1. Create a base directory in which all modules will be cloned (e.g. `mkdir ~/wms_modules`).
+2. `cd` into the directory created from last step
+3. Clone each of these repositories from the base directory (a subdirectory will automatically be created in the base directory for each repository):
+
+- `git clone https://github.com/lucianpls/libahtse.git`
+- `git clone https://github.com/lucianpls/AHTSE.git`
+- `git clone https://github.com/lucianpls/libicd.git`
+- `git clone https://github.com/lucianpls/mod_mrf.git`
+- `git clone https://github.com/lucianpls/mod_receive.git`
+- `git clone https://github.com/lucianpls/mod_sfim.git`
+- `git clone https://github.com/lucianpls/mod_reproject.git`
+- `git clone https://github.com/lucianpls/mod_convert.git`
+
+Ensure all the directories are next to each other, this is important for building the modules as they reference each other.
+
+## Preparing building/compiling AHTSE modules
+
+Create directories where modules were to be built.
+
+```bash
+mkdir ~/modules
+mkdir ~/libs
+```
+
+## Building `mod_mrf` module
+
+From the base directory, `cd mod_mrf/src/` and create a Makefile by copying from the provided example:
+
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
+
+Edit `Makefile.lcl`, find the line that defines `EXTRA_INCLUDES`, and add the following lines _below_ that line:
+
+```makefile
 EXTRA_INCLUDES += -I../../libahtse/src
 EXTRA_INCLUDES += -I../../libicd/src
 EXTRA_INCLUDES += -I../../mod_receive/src
 ```
-3. Type `make` to build the module, and `make install` to install the resulting library file (for example, mod_mrf.so on linux) to the apache modules location.  Prefacing this with `sudo` may be required.
-4. Add the module to Apache's module loader config file by editing the file `/etc/apache2/loadmodule.conf` and adding the following line at the end:
-`LoadModule mrf_module      /usr/lib64/apache2-prefork/mod_mrf.so`
+
+Type `make` to build the module, and `make install` to install the resulting library file in `~/modules` to the apache modules location.
+
+Add the module to Apache's `modules-available` by creating the file `/etc/apache2/modules-available/mrf.load` and adding the line:
+
+```conf
+LoadModule mrf_module /usr/lib64/apache2-prefork/mod_mrf.so
+```
+
 Note the `-prefork` in the path, and make sure that this path matches the apache2 install path on the system.  In other words, add `-prefork` to the end of the **MOD_PATH** from your Makefile, and then verify that the resulting path exists on the filesystem.  This is a directory created by Apache at runtime, so it may be necessary to restart on a system where Apache was newly installed.  At startup, Apache takes the modules from the **MOD_PATH** location and copies them to the prefork directory.
-Note: On Ubuntu 16.04, no `-prefork` is created and the `so` file is placed in the same directory as specified
-5. Add the mrf module to the list of **APACHE_MODULES** in the file `/etc/sysconfig/apache2`.  This is a space-delimited list of modules. Note that the module names do not have the **mod_** prefix or the **.so** suffix, so just add **mrf** to the end of this line.  (Note: This does not seem to exist on Ubuntu 16.04)
-6. Restart Apache using the command: `sudo service apache2 restart`
-7. Verify that the module is loaded by typing:
-`sudo apachectl -M`
+
+Restart Apache using the command: `sudo apachectl restart`
+
+Verify that the module is loaded by typing: `sudo apachectl -M`
+
 There should be a **mrf_module** line in the listing.  If not, troubleshoot the above steps.
+
 Another way to list running modules is to use a browser to view the Apache server info page `http://localhost/server-info`.  Some Apache installs do not provide the server module required to view this page by default.  If the page does not load, it is probably because the info module isn't loaded in Apache.  To add this module, add the following line to `/etc/apache2/loadmodule.conf`:
-`LoadModule mod_info_module      /usr/lib64/apache2-prefork/mod_info.so`
+
+`LoadModule mod_info_module /usr/lib64/apache2-prefork/mod_info.so`
 and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`.  Finally, restart apache2 using the command in the previous step.
 
-## Add the _mod_receivef_ module
+## Add the `mod_receivef`module
+
 1. From the base directory, `cd mod_receive/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
 2. No **EXTRA_INCLUDES** definitions are needed for this module.
 3. Same as MRF example above.
@@ -67,7 +105,8 @@ and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`
 6. Restart Apache.
 7. Verify that the **receive_module** is listed in the `apachectl -M` output.
 
-## Add the _mod_sfim_ module
+## Add the `mod_sfim` module
+
 1. From the base directory, `cd mod_sfim/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
 2. No **EXTRA_INCLUDES** definitions are needed for this module.
 3. Same as MRF example above.
@@ -76,7 +115,8 @@ and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`
 6. Restart Apache.
 7. Verify that the **sfim_module** is listed in the `apachectl -M` output.
 
-## Add the _mod_reproject_ module
+## Add the `mod_reproject` module
+
 1. From the base directory, `cd mod_reproject/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl` 
 2. Add the 3 additional **EXTRA_INCLUDES** lines to Makefile.lcl, as described in the mrf module instructions above.
 3. Same as MRF example above.
@@ -85,8 +125,9 @@ and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`
 6. Restart Apache.
 7. Verify that the **reproject_module** is listed in the `apachectl -M` output.
 
-## Add the _mod_convert_ module
-1. From the base directory, `cd mod_convert/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl` 
+## Add the `mod_convert` module
+
+1. From the base directory, `cd mod_convert/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
 2. Add the 3 additional **EXTRA_INCLUDES** lines to Makefile.lcl, as described in the mrf module instructions above.
 3. Same as MRF example above.
 4. It does not appear to be necessary to add a LoadModule command to `/etc/apache2/loadmodule.conf` for this module.
@@ -97,6 +138,7 @@ and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`
 At this point, the system is ready to operate as a WMS tile-serving engine.
 
 ## Configure Apache Virtual Host to Serve MRF Data
+
 The Apache server has a directory from which web content is served.  This can be the default directory based on the install, or Apache can be configured with a Virtual Host that has special behavior based on the address of received requests.  AHTSE is configured to provide this behavior for the WMS data.
 
 Configuring Apache with a Virtual Host is optional for AHTSE.  However, it provides flexibility with the web server so that it can be used for different types of content if so needed.  Some of the following steps would still be needed without a Virtual Host setup.
@@ -108,7 +150,8 @@ Configuring Apache with a Virtual Host is optional for AHTSE.  However, it provi
 1. Set log file locations for logging accesses and errors.
 
 Here is an example from the Utah server configuration file `/etc/apache2/vhosts.d/openspace.conf`:
-```
+
+```apache
 #(IP address below is fake)
 <VirtualHost 000.000.000.000:80>
     ServerName openspace.sci.utah.edu

--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -49,7 +49,7 @@ Some, but not all, modules require include files from other modules or related l
 
 Ensure all the directories are next to each other, this is important for building the modules as they reference each other.
 
-## Preparing building/compiling AHTSE modules
+## Preparing building/compiling AHTSE modules/libraries
 
 Create directories where modules were to be built.
 
@@ -59,9 +59,41 @@ mkdir ~/lib
 mkdir ~/include
 ```
 
-## Building `mod_mrf` module
+You will also add a line to the `/etc/ld.so.conf.d/libc.conf` where the `lib` is created.
 
-From the base directory, `cd mod_mrf/src/` and create a Makefile by copying from the provided example:
+Add the following line to the bottom of the file:
+
+```conf
+/home/[user]/lib
+```
+
+The libraries build will output to that directory, and will be used by Apache as a module.
+
+## Building AHTSE modules/libraries
+
+### Building `libicd` library
+
+From the base directory (in this case `~/wms_modules`), `cd libicd/src/` and create a Makefile by copying from the provided example:
+
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
+
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
+
+### Building `libahtse` module
+
+From the base directory (in this case `~/wms_modules`), `cd libahtse/src/` and create a Makefile by copying from the provided example:
+
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
+
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
+
+### Building `mod_mrf` module
+
+From the base directory (in this case `~/wms_modules`), `cd mod_mrf/src/` and create a Makefile by copying from the provided example:
 
 ```bash
 cp Makefile.lcl.example Makefile.lcl
@@ -77,78 +109,176 @@ EXTRA_INCLUDES += -I../../mod_receive/src
 
 Type `make` to build the module, and `make install` to install the resulting library file in `~/modules` to the apache modules location.
 
-Add the module to Apache's `modules-available` by creating the file `/etc/apache2/modules-available/mrf.load` and adding the line:
+### Building `mod_convert`
 
-```conf
-LoadModule mrf_module /usr/lib64/apache2-prefork/mod_mrf.so
+From the base directory (in this case `~/wms_modules`), `cd mod_convert/src/` and create a Makefile by copying from the provided example:
+
+```bash
+cp Makefile.lcl.example Makefile.lcl
 ```
 
-Note the `-prefork` in the path, and make sure that this path matches the apache2 install path on the system.  In other words, add `-prefork` to the end of the **MOD_PATH** from your Makefile, and then verify that the resulting path exists on the filesystem.  This is a directory created by Apache at runtime, so it may be necessary to restart on a system where Apache was newly installed.  At startup, Apache takes the modules from the **MOD_PATH** location and copies them to the prefork directory.
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
 
-Restart Apache using the command: `sudo apachectl restart`
+### Building `mod_receive`
 
-Verify that the module is loaded by typing: `sudo apachectl -M`
+From the base directory (in this case `~/wms_modules`), `cd mod_receive/src/` and create a Makefile by copying from the provided example:
 
-There should be a **mrf_module** line in the listing.  If not, troubleshoot the above steps.
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
 
-Another way to list running modules is to use a browser to view the Apache server info page `http://localhost/server-info`.  Some Apache installs do not provide the server module required to view this page by default.  If the page does not load, it is probably because the info module isn't loaded in Apache.  To add this module, add the following line to `/etc/apache2/loadmodule.conf`:
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
 
-`LoadModule mod_info_module /usr/lib64/apache2-prefork/mod_info.so`
-and also add **info** to the **APACHE_MODULES** line in `/etc/sysconfig/apache2`.  Finally, restart apache2 using the command in the previous step.
+### Building `mod_reproject`
 
-## Add the `mod_receivef`module
+From the base directory (in this case `~/wms_modules`), `cd mod_reproject/src/` and create a Makefile by copying from the provided example:
 
-1. From the base directory, `cd mod_receive/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
-2. No **EXTRA_INCLUDES** definitions are needed for this module.
-3. Same as MRF example above.
-4. It does not appear to be necessary to add a LoadModule command to `/etc/apache2/loadmodule.conf` for this module.
-5. Add **receive** to the list of **APACHE_MODULES** in the `/etc/sysconfig/apache2` file.
-6. Restart Apache.
-7. Verify that the **receive_module** is listed in the `apachectl -M` output.
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
 
-## Add the `mod_sfim` module
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
 
-1. From the base directory, `cd mod_sfim/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
-2. No **EXTRA_INCLUDES** definitions are needed for this module.
-3. Same as MRF example above.
-4. It does not appear to be necessary to add a LoadModule command to `/etc/apache2/loadmodule.conf` for this module.
-5. Add **sfim** to the list of **APACHE_MODULES** in the `/etc/sysconfig/apache2` file.
-6. Restart Apache.
-7. Verify that the **sfim_module** is listed in the `apachectl -M` output.
+**Note: The module generated is `mod_retile`, this is still the same module, just renamed.**
 
-## Add the `mod_reproject` module
+### Building `mod_sfim`
 
-1. From the base directory, `cd mod_reproject/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl` 
-2. Add the 3 additional **EXTRA_INCLUDES** lines to Makefile.lcl, as described in the mrf module instructions above.
-3. Same as MRF example above.
-4. It does not appear to be necessary to add a LoadModule command to `/etc/apache2/loadmodule.conf` for this module.
-5. Add **reproject** to the list of **APACHE_MODULES** in the `/etc/sysconfig/apache2` file.
-6. Restart Apache.
-7. Verify that the **reproject_module** is listed in the `apachectl -M` output.
+From the base directory (in this case `~/wms_modules`), `cd mod_sfim/src/` and create a Makefile by copying from the provided example:
 
-## Add the `mod_convert` module
+```bash
+cp Makefile.lcl.example Makefile.lcl
+```
 
-1. From the base directory, `cd mod_convert/src/` and create a Makefile by copying from the provided example: `cp Makefile.lcl.example Makefile.lcl`
-2. Add the 3 additional **EXTRA_INCLUDES** lines to Makefile.lcl, as described in the mrf module instructions above.
-3. Same as MRF example above.
-4. It does not appear to be necessary to add a LoadModule command to `/etc/apache2/loadmodule.conf` for this module.
-5. Add **convert** to the list of **APACHE_MODULES** in the `/etc/sysconfig/apache2` file.
-6. Restart Apache.
-7. Verify that the **convert_module** is listed in the `apachectl -M` output.
+Run `make` to build the dependencies, then `make install` to automatically place the dependencies in the correct location.
 
-At this point, the system is ready to operate as a WMS tile-serving engine.
+## Installing modules for Apache
+
+### Installing `mod_mrf`
+
+To install `mod_mrf`, you need to create a new Apache module in `/etc/apache2/mods-available` called `mrf.load`.
+
+The contents of this file will consist of:
+
+```conf
+LoadFile /home/[user]/modules/libahtse.so
+LoadModule mrf_module /home/[user]/modules/mod_mrf.so
+```
+
+Create a soft-symlink to `mods-enabled` via this command:
+
+```bash
+ln -s /etc/apache2/mods-available/mrf.load /etc/apache2/mods-enabled/mrf.load
+```
+
+You may need `sudo` to execute.
+
+Restart the Apache server with `sudo apachectl restart`, there will be a message that looks like:
+
+To verify if the module is loaded, run `sudo apachectl -M` and check if `mrf_module` is loaded.
+
+### Installing `mod_convert`
+
+To install `mod_convert`, you need to create a new Apache module in `/etc/apache2/mods-available` called `convert.load`.
+
+The contents of this file will consist of:
+
+```conf
+LoadModule convert_module /home/[user]/modules/mod_convert.so
+```
+
+Create a soft-symlink to `mods-enabled` via this command:
+
+```bash
+ln -s /etc/apache2/mods-available/convert.load /etc/apache2/mods-enabled/convert.load
+```
+
+You may need `sudo` to execute.
+
+Restart the Apache server with `sudo apachectl restart`, there will be a message that looks like:
+
+To verify if the module is loaded, run `sudo apachectl -M` and check if `convert_module` is loaded.
+
+### Installing `mod_receive`
+
+To install `mod_receive`, you need to create a new Apache module in `/etc/apache2/mods-available` called `receive.load`.
+
+The contents of this file will consist of:
+
+```conf
+LoadModule receive_module /home/[user]/modules/mod_receive.so
+```
+
+Create a soft-symlink to `mods-enabled` via this command:
+
+```bash
+ln -s /etc/apache2/mods-available/receive.load /etc/apache2/mods-enabled/receive.load
+```
+
+You may need `sudo` to execute.
+
+Restart the Apache server with `sudo apachectl restart`, there will be a message that looks like:
+
+To verify if the module is loaded, run `sudo apachectl -M` and check if `receive_module` is loaded.
+
+### Installing `mod_retile`
+
+To install `mod_retile`, you need to create a new Apache module in `/etc/apache2/mods-available` called `retile.load`.
+
+The contents of this file will consist of:
+
+```conf
+LoadModule retile_module /home/[user]/modules/mod_retile.so
+```
+
+Create a soft-symlink to `mods-enabled` via this command:
+
+```bash
+ln -s /etc/apache2/mods-available/retile.load /etc/apache2/mods-enabled/retile.load
+```
+
+You may need `sudo` to execute.
+
+Restart the Apache server with `sudo apachectl restart`, there will be a message that looks like:
+
+To verify if the module is loaded, run `sudo apachectl -M` and check if `retile_module` is loaded.
+
+### Installing `mod_sfim`
+
+To install `mod_sfim`, you need to create a new Apache module in `/etc/apache2/mods-available` called `sfim.load`.
+
+The contents of this file will consist of:
+
+```conf
+LoadModule sfim_module /home/[user]/modules/mod_sfim.so
+```
+
+Create a soft-symlink to `mods-enabled` via this command:
+
+```bash
+ln -s /etc/apache2/mods-available/sfim.load /etc/apache2/mods-enabled/sfim.load
+```
+
+You may need `sudo` to execute.
+
+Restart the Apache server with `sudo apachectl restart`, there will be a message that looks like:
+
+To verify if the module is loaded, run `sudo apachectl -M` and check if `sfim_module` is loaded.
 
 ## Configure Apache Virtual Host to Serve MRF Data
 
-The Apache server has a directory from which web content is served.  This can be the default directory based on the install, or Apache can be configured with a Virtual Host that has special behavior based on the address of received requests.  AHTSE is configured to provide this behavior for the WMS data.
+The Apache server has a directory from which web content is served. This can be the default directory based on the install, or Apache can be configured with a Virtual Host that has special behavior based on the address of received requests.
 
-Configuring Apache with a Virtual Host is optional for AHTSE.  However, it provides flexibility with the web server so that it can be used for different types of content if so needed.  Some of the following steps would still be needed without a Virtual Host setup.
+AHTSE is configured to provide this behavior for the WMS data.
+
+Configuring Apache with a Virtual Host is optional for AHTSE. However, it provides flexibility with the web server so that it can be used for different types of content if so needed.
+
+Some of the following steps would still be needed without a Virtual Host setup.
 
 1. Add a configuration file in Apache's virtual hosts directory (e.g. `/etc/apache2/vhosts.d/`) by copying & renaming a template file provided in the install (e.g. **vhost.template**).
-1. Modify the **\<VirtualHost\>** tag to match the hostname or URL that you want to be directed to AHTSE requests.
-1. Set **\<DocumentRoot\>** to the Apache web content directory structure containing the **.wms** files.  See the wiki on importing MRF data sets, ".wms file" section for more information.
-1. Add specific detail to **\<Directory\>** tag, including where **.wms** files are located in the Apache web content directory, server options, permissions.
-1. Set log file locations for logging accesses and errors.
+2. Modify the **\<VirtualHost\>** tag to match the hostname or URL that you want to be directed to AHTSE requests.
+3. Set **\<DocumentRoot\>** to the Apache web content directory structure containing the **.wms** files.  See the wiki on importing MRF data sets, ".wms file" section for more information.
+4. Add specific detail to **\<Directory\>** tag, including where **.wms** files are located in the Apache web content directory, server options, permissions.
+5. Set log file locations for logging accesses and errors.
 
 Here is an example from the Utah server configuration file `/etc/apache2/vhosts.d/openspace.conf`:
 

--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -7,7 +7,7 @@ parent: WMS
 nav_order: 1
 ---
 
-This wiki covers the steps required to get an OpenSpace WMS (Web Map Server) configured & running. This serves MRF (Meta Raster Format) files. Another name for this service is AHTSE (An Httpd/Apache Tile-Serving Engine).
+This wiki covers the steps required to get an OpenSpace WMS (Web Map Server) configured & running. This serves MRF (Meta Raster Format) files. Another name for this service is [AHTSE](https://github.com/lucianpls/AHTSE) (Apache HTTPD Tile Server Ecosystem).
 [This wiki](server-import) covers the steps involved in importing WMS dataset(s) so that the AHTSE can serve tiles from the set. [This wiki](server-conversion) covers the steps involved in converting a raw raster image into the MRF format.
 
 These instructions are specific to a Ubuntu Linux 22.04 server install. However other Linux distributions can work with some packages or paths changed around.
@@ -273,6 +273,20 @@ AHTSE is configured to provide this behavior for the WMS data.
 Configuring Apache with a Virtual Host is optional for AHTSE. However, it provides flexibility with the web server so that it can be used for different types of content if so needed.
 
 Some of the following steps would still be needed without a Virtual Host setup.
+
+You also need to configure a directory to be used to serve the WMS data, this can be any directory however you need to make it accessible to Apache, you can use the `www-data` (or `apache` if on CentOS) group to serve this data.
+
+```bash
+mkdir /var/www/openspace
+
+# If not on CentOS
+chown -R www-data:www-data /var/www/openspace/*
+
+# If on CentOS
+chown -R apache:apache /var/www/openspace/*
+```
+
+To set up a server configuration to serve WMS data:
 
 1. Add a configuration file in Apache's virtual hosts directory (e.g. `/etc/apache2/vhosts.d/`) by copying & renaming a template file provided in the install (e.g. **vhost.template**).
 2. Modify the **\<VirtualHost\>** tag to match the hostname or URL that you want to be directed to AHTSE requests.

--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -55,7 +55,8 @@ Create directories where modules were to be built.
 
 ```bash
 mkdir ~/modules
-mkdir ~/libs
+mkdir ~/lib
+mkdir ~/include
 ```
 
 ## Building `mod_mrf` module

--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -183,6 +183,7 @@ To install `mod_convert`, you need to create a new Apache module in `/etc/apache
 The contents of this file will consist of:
 
 ```conf
+LoadFile /home/[user]/modules/libahtse.so
 LoadModule convert_module /home/[user]/modules/mod_convert.so
 ```
 

--- a/docs/builders/wms/server-install.md
+++ b/docs/builders/wms/server-install.md
@@ -286,41 +286,39 @@ chown -R www-data:www-data /var/www/openspace/*
 chown -R apache:apache /var/www/openspace/*
 ```
 
-To set up a server configuration to serve WMS data:
+Now you should be ready to create and configure a Virtual Host from Apache.
 
-1. Add a configuration file in Apache's virtual hosts directory (e.g. `/etc/apache2/vhosts.d/`) by copying & renaming a template file provided in the install (e.g. **vhost.template**).
-2. Modify the **\<VirtualHost\>** tag to match the hostname or URL that you want to be directed to AHTSE requests.
-3. Set **\<DocumentRoot\>** to the Apache web content directory structure containing the **.wms** files.  See the wiki on importing MRF data sets, ".wms file" section for more information.
-4. Add specific detail to **\<Directory\>** tag, including where **.wms** files are located in the Apache web content directory, server options, permissions.
-5. Set log file locations for logging accesses and errors.
+Create a new site config in `/etc/apache2/sites-available` in a format that is `XXX-[generic-name].conf` where `X` is a number and the `[generic-name]` can be any relevant name.
 
-Here is an example from the Utah server configuration file `/etc/apache2/vhosts.d/openspace.conf`:
+Copy and paste the following configuration into the file:
 
 ```apache
-#(IP address below is fake)
-<VirtualHost 000.000.000.000:80>
-    ServerName openspace.sci.utah.edu
-    DocumentRoot /srv/www/vhosts/openspace
-    HostnameLookups Off
-    UseCanonicalName Off
-    ServerSignature Off
-    <IfModule mod_userdir.c>
-        UserDir public_html
-        Include /etc/apache2/mod_userdir.conf
-    </IfModule>
-    <Directory "/srv/www/vhosts/openspace">
-        Options Indexes FollowSymLinks
-        AllowOverride None
-        <IfModule !mod_access_compat.c>
-            Require all granted
-        </IfModule>
-        <IfModule mod_access_compat.c>
-            Order allow,deny
-            Allow from all
-        </IfModule>
+<VirtualHost *:80>
+    ServerName [domain]
+    DocumentRoot /var/www/openspace
+    <Directory />
+        Options +Indexes
+        Require all granted
     </Directory>
-    ErrorLog /var/log/apache2/openspace/openspace_error_log
-    LogLevel error
-    TransferLog /var/log/apache2/openspace/openspace_access_log
 </VirtualHost>
 ```
+
+**Make sure you change the `[domain]` setting to your preferred domain name**
+
+After that, you create a sym-link to `/etc/apache2/sites-enabled` and restart Apache.
+
+```bash
+ln -s /etc/apache2/sites-available/XXX-[generic-name].conf /etc/apache2/sites-enabled/XXX-[generic-name].conf
+apachectl restart
+```
+
+You may need `sudo` to execute.
+
+This configuration file:
+
+- Sets the VirtualHost to respond on all requests on port `80`
+- Sets a server name to respond to (e.g., browsing to it via a web browser)
+- Sets a served directory to store and server `.wms` data and files
+- Sets permissions to be set on the served directory
+
+To retrieve and serve content, you now can head to [this wiki](server-import) to start serving WMS data to OpenSpace clients.


### PR DESCRIPTION
This updates all the documentation and steps to get AHTSE up and running.

Follows steps primarily in Ubuntu 22.04 but other distributions and WSL will also work fine with these installation requirements and instructions.