### PR TITLE
Restructure files about releases, to put them in one place

### DIFF
--- a/docs/general/releases/changelog.md
+++ b/docs/general/releases/changelog.md
@@ -1,54 +1,17 @@
 ---
-title: Releases
+title: Release Changelog
 layout: default
 
-parent: Home
-nav_order: 1
+grand_parent: Home
+parent: Releases
+nav_order: 3
 ---
 
-# Releases
-OpenSpace versions are labeled by a version number of the form `MM.mm.rr`,  where `MM` is the major version number, `mm` is the minor version number, and `rr` is the release number (see [Semantic Versioning](https://semver.org)).  In some cases there may be an additional number at the end, `MM.mm.rr.bb`, where bb is the build number, but that will only be for development and testing, not for public release.
+# Release Changelog
+This page contains detailed changelogs for each of the releases, sorted based on what are new features, new content, bug fixes, as well as breaking changes. The messages are taken straight from the commit messages on [OpenSpace GitHub](https://github.com/OpenSpace/OpenSpace).
 
 1. TOC
 {:toc}
-
-# Overview
-As development proceeds, some versions get tagged with names.  This table indicates which version numbers go with which tags, and some notes about each:
-
-| Version | _Name_ | _Date_ | _Description_ |
-| ------- | ------ | ------ | - |
-| 0.18.2 | Beta-11 | 2022-12-24 | This is a second patch release for the eleventh beta release |
-| 0.18.1 | Beta-11 | 2022-11-22 | This is a patch release for the eleventh beta release |
-| 0.18.0 | Beta-11 | 2022-05-06 | This is the eleventh beta release and the first in 2022 |
-| 0.17.2 | Beta-10 | 2021-08-27 | This is a patch release for the tenth beta that addresses an issue with Earth terrain |
-| 0.17.1 | Beta-10 | 2021-08-09 | This is a patch release for the tenth beta that addresses initial bug reports |
-| 0.17.0 | Beta-10 | 2021-07-14 | This is the tenth beta release and the second in 2021 |
-| 0.16.1 | Beta-9 | 2021-05-07 | This is the ninth beta release and the first in 2021 |
-| 0.16.0 | Beta-8 | 2020-12-09 | This is the eigth beta release for the end of 2020 |
-| 0.15.2 | Beta-7 | 2020-06-26 | This is the seventh beta release for OpenSpace for the summer of 2020 |
-| 0.15.1 | Beta-6 | 2020-02-17 | This is the sixth beta release for OpenSpace in conjunction with the 4th annual developer's meeting |
-| 0.15.0 | Beta-5 | 2019-09-17 | This is the fifth beta release for OpenSpace released on September, 17th, 2019 for the ASTC conference |
-| 0.14.1 | Beta-4 | 2019-06-04 | This is the first patch release for the fourth beta |
-| 0.14.0 | Beta-4 | 2019-05-20 | This is the fourth beta release for OpenSpace released on the 20th of May, 2019 |
-| 0.13.0 | Beta-3 | 2018-11-05 | This is the third beta release for OpenSpace released on the 5th of November, 2018 |
-| 0.12.0 | Beta-2 | 2018-07-11 | This is the second beta release for OpenSpace released on the 11th July 2018 in the aftermath of IPS in Toulouse, France. |
-| 0.11.1 | Beta-1 | 2018-02-13 | This is a patch release for the beta-1 version released on January 1st, 2018. It mainly fixes bugs and issues that have come up for users with the beta-1 release of OpenSpace. |
-| 0.11.0 | Beta-1 | 2018-01-01 | This is the first beta release for OpenSpace released on January 1st, 2018. It contains all of the previously released features + new content and feature updates. |
-| 0.10.0 | Prerelease-15 | 2017-10-24 | This prerelease is a collection of features that have been developed since the last public prerelease version for release at the Association of Science – Technology Centers (ASTC) conference. |
-| 0.9.0 | Prerelease-14 | 2017-07-21 | This prerelease is a collection of features that have been developed since the last public prerelease version. |
-| 0.8.0 | Prerelease-13 | 2017-04-18 | Prerelease for the Earth Day 2017 |
-| 0.7.0 | Prerelease-12 | 2016-02-19 | NAOJ presentation |
-| 0.6.0 | Prerelease-11 | 2016-12-14 | AGU presentation |
-| 0.5.0 | Prerelease-10 | 2016-09-25 | Norrköping's Kulturnatten presentation |
-| 0.4.0 | Prerelease-9 | 2016-07-11 | This pre-release version was prepared for a meeting at the AMNH of the ISI User Network. |
-| 0.3.4 | Prerelease-8 | 2016-06-22 | IPS exhibition |
-| 0.3.3 | Prerelease-8 | 2016-06-07 | EuroVis presentation |
-| 0.3.2 | Prerelease-8 | 2016-04-15 | CCMC Show |
-| 0.3.1 | Prerelease-8 | 2016-03-03 | New Horizons Show |
-| 0.3.0 | Prerelease-8 | 2015-07-16 | |
-| 0.2.1 | Prerelease-7 | 2015-07-15 | New Horizons Show |
-| 0.2.0 | Prerelease-7 | 2015-07-08 | This prerelease was published for a global, networked event in celebration of New Horizon’s closest approach to Pluto. |
-| 0.1.0 | Prerelease-5 | 2015-05-14 | This prerelease was published for the Pluto-Palooza event held at the AMNH in New York. |
 
 ***
 
@@ -80,7 +43,7 @@ As development proceeds, some versions get tagged with names.  This table indica
  - Fix the Mars profile so that Perseverance and Insight do not land inside Mars anymore and stay there as well (#2049)
  - Update OsirisREx kernels to include a missing kernel file that would prevent the profile from loading correctly (#2177)
  - Reorganized the assets for the NASA Treks values to make it less likely to end up with too long file paths on Windows when installing OpenSpace in a nested folder (#2311)
- - Fixed issue with Show All Trails / Hide all Trails when executed in a profile that did not have `*trail` and `*Trail` scene graph nodes 
+ - Fixed issue with Show All Trails / Hide all Trails when executed in a profile that did not have `*trail` and `*Trail` scene graph nodes
  - Updated the bounding spheres for Vesta and the Orion Nebula to make it possible to use the Fly-To feature with these objects (#2259)
  - Fixed a typo in the reset_loop_action.asset that prevented the asset from being able to be included
  - Fixed spelling mistakes in the Andromeda constellation image (#2129)
@@ -122,7 +85,7 @@ As development proceeds, some versions get tagged with names.  This table indica
 - Version: 0.18.0
 - Date: 2022-05-06
 - Finished: [5877112103cdcb894695c214c21c15d2625fbe0b](https://github.com/OpenSpace/OpenSpace/commit/5877112103cdcb894695c214c21c15d2625fbe0b)
-- See [Release Notes](http://wiki.openspaceproject.com/docs/users/release-notes/v0180.html) for user-focused highlights.
+- See [Release Notes](../releases/release-notes/v0180) for user-focused highlights.
 
 ## Features
 ### SkyBrowser
@@ -169,30 +132,30 @@ Various user interface improvements in the launcher and the in-game interface
   - Add preliminary support for multiple simultaneous joysticks (#1787)
   - Automatically use 66% of the monitor size by default instead of 1280x720 (#1883)
   - Pass information about the operating system to the version reporter script (#1865)
-  - Add a new environment variable OPENSPACE_GLOBEBROWSING that is queried for the extra download files for offline planetary surface images 
+  - Add a new environment variable OPENSPACE_GLOBEBROWSING that is queried for the extra download files for offline planetary surface images
   - Update CEF version which improves the responsiveness of the user interface (#1114)
   - Add the ability to define and use custom properties using the `openspace.addCustomProperty` Lua function (#2064)
   - Backwards incompatible change to the Astrocasting protocol that reduces the amount of data that is transferred while connected to an Astrocasting session (#1985)
   - Improve support for the handling of SpaceMouse input devices and XBox controllers (#1989)
   - Add error message when trying to access Gaia module on Mac (#843)
-  - Add two properties to control the font color of the Rotation, Zoom, and Roll toggles (#1726) [Thanks BlueVista] 
+  - Add two properties to control the font color of the Rotation, Zoom, and Roll toggles (#1726) [Thanks BlueVista]
   - Added SpoutFlatProjection type [Thanks Marco @ Elumenati]
   - Clean up the remainders of the native GUI to harmonize its organization with the WebGUI (#2060)
   - Make the font size of the Lua console dependent on the DPI scaling for increased readability
-  
+
 ## Content
 ### New Assets
   - Add most of the image sequences available from NOAA’s Science-on-a-Sphere (#1863)
   - Add new assets provided access to a large number of NASA TREKs Moon, Mars, and Mercury layers layers (#888)
   - Add a new profile and assets that show the solar activity in July 2012, a time in which a few coronal mass ejections were ejected into the solar system
-  - Add new asset containing the Starlink satellites (#1818) 
+  - Add new asset containing the Starlink satellites (#1818)
   - Add new asset showing the active satellites (#1805)
   - Add model-based representations of the Mars moons Phobos and Deimos (#1963)
   - Add a model for the Eiffel tower with an accompanying action to place the model underneath the camera location to be used for scale references
   - Add a large number of new actions that are useful in their own right, but also serve as examples for implementing new user-defined actions (#2077)
   - Add trails for the planets barycenters which are disabled by default
 
-### Fixes to existing assets 
+### Fixes to existing assets
   - Update the general planetary spice kernel to a new version that extending the range of planetary positions to covering 1550-2650 (#2061)
   - Removed the Orion nebula model from the default profile
   - Updates to JWST profile
@@ -388,8 +351,8 @@ Various user interface improvements in the launcher and the in-game interface
 # Beta-10 [0.17.0]
  - Version: 0.17.0
  - Date: 2021-07-16
- - Finished: [3025fbc200ffdd8cf80f95c5f251d0daf793fbdf](https://github.com/OpenSpace/OpenSpace/commit/3025fbc200ffdd8cf80f95c5f251d0daf793fbdf) 
- - See [Release Notes](http://wiki.openspaceproject.com/docs/users/release-notes/v0170.html) for user-focused highlights.
+ - Finished: [3025fbc200ffdd8cf80f95c5f251d0daf793fbdf](https://github.com/OpenSpace/OpenSpace/commit/3025fbc200ffdd8cf80f95c5f251d0daf793fbdf)
+ - See [Release Notes](../releases/release-notes/v0170) for user-focused highlights.
 
 ### Features
  - Added drag and drop support for images and assets (#1497)
@@ -429,7 +392,7 @@ Various user interface improvements in the launcher and the in-game interface
     - Added view frustrum for JWST
     - Added Hubble Deep Field image
     - Added other Lagrange points
-  - Updated osirisrex profile (#1623) 
+  - Updated osirisrex profile (#1623)
     - Updated files for OSIRIS-REx return
     - Changed osirisrex assets to bring mission events up to date
     - Added hi-res 75cm Bennu model from asteroidmission.org
@@ -449,8 +412,8 @@ Various user interface improvements in the launcher and the in-game interface
    - Added IntListProperty, DoubleListProperty
  - Added GlobeTranslation Documentation to exported documentations (closes #1566)
  - Removed unused parameters and document the remaining properties of RenderableGlobe (closes #1470)
- - Enabled Screenspace renderable to have a multiplicative color 
- - Fixed missing documentation for time.interpolateTime 
+ - Enabled Screenspace renderable to have a multiplicative color
+ - Fixed missing documentation for time.interpolateTime
  - Added fixed time for spice translations and rotations
  - Added simple animation example asset
 
@@ -497,7 +460,7 @@ Various user interface improvements in the launcher and the in-game interface
  - Fixed interpolation problem with playback of session recording in HD (#1373)
  - Fixed session recording needs initial simulation time rate to be saved in file (#1506)
  - Fix for Voyager 2 trail (#1582)
- - Fixed side by side rendering (PR #1613) 
+ - Fixed side by side rendering (PR #1613)
  - Fixed an issue with syncing Gaia profile
  - Fixed misaligned surface textures for Callisto, Europa, Jupiter, Titan, and Saturn
  - Mostly eliminated an issue where planets disappear when changing focus (#1455)
@@ -509,10 +472,10 @@ Various user interface improvements in the launcher and the in-game interface
  - Read Horizons file with double precision
  - Fixed some small issues with trail identifiers
  - Comment out FOV for REXIS as it has an unsupported shape (closes #1650)
- - Prevent NaN values in StaticTranslation by limiting min and max size 
+ - Prevent NaN values in StaticTranslation by limiting min and max size
  - Added exponent to GlobeTranslation altitude slider
  - Correctly pass in the irradianceFactor into the inscatter radiance for atmosphere (closes #1660)
- - Avoid non-supported ranges for exponential slider (#1672) 
+ - Avoid non-supported ranges for exponential slider (#1672)
  - Fixed issue with interrupted fisheye rendering between cube maps (closes #1275)
  - Fixes to fullscreen1080 and spoutOutput config files
  - Adapt addFocusNodes for GlobeTranslation
@@ -564,7 +527,7 @@ Various user interface improvements in the launcher and the in-game interface
  - Version: 0.16.1
  - Date: 2021-05-07
  - Finished: [452d4e9626c58629709c7ed061fedc7141964727](https://github.com/OpenSpace/OpenSpace/commit/452d4e9626c58629709c7ed061fedc7141964727)
- - See [Release Notes](http://wiki.openspaceproject.com/docs/users/release-notes/v0161.html) for user-focused highlights.
+ - See [Release Notes](../releases/release-notes/v0161) for user-focused highlights.
 
 ### Features
  - Added Drag and Drop support for images and assets (#1497)
@@ -601,9 +564,9 @@ Various user interface improvements in the launcher and the in-game interface
  - Version: 0.16.0
  - Date: 2020-12-10
  - Finished: [c13b211add7b1bc4336de34ee6cb4f6064420242](https://github.com/OpenSpace/OpenSpace/commit/c13b211add7b1bc4336de34ee6cb4f6064420242)
- 
+
 ## Changelog
-See [Release notes](http://wiki.openspaceproject.com/docs/users/release-notes/v0160.html) for user-focused highlights.
+See [Release notes](../releases/release-notes/v0160) for user-focused highlights.
 
 ### Features
 - Add new 'Profiles' feature that replaces the `*.scene` files with a more descriptive format that enables editing with a graphical user interface
@@ -704,13 +667,13 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Version: 0.15.2
  - Date: 2020-06-22
  - Finished: [076a96e651a59cc9f330ef94c09259db2dbd41de](https://github.com/OpenSpace/OpenSpace/commit/076a96e651a59cc9f330ef94c09259db2dbd41de)
- 
+
 ## Changelog
 ### Features
  - Added new meta information to the assets that is automatically collected into the documentation/index.html to provide direct information about the license state of the current scene
  - Added a new version of SGCT that should improve performance and future extensibility
    - Added support for cylindrical and equirectangular output methods
- - Added a feature for touch interface to enable a continous pinch gesture to continue to zoom in without the need to repeat the pinch gesture 
+ - Added a feature for touch interface to enable a continous pinch gesture to continue to zoom in without the need to repeat the pinch gesture
  - Added the ability to change the line width of wire-type meshes (#1153)
  - Added the ability to invert mouse buttons (#697)
  - Added the ability for a vertical offset for a screen log
@@ -725,7 +688,7 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Added the C/2019 Y4 (ATLAS) comet (thanks to Dan Tell)
  - Added time range to Voyager rotations to make that scene more useful
  - Fixed spelling errors with Uranus label and the CTX surface layer
- 
+
 ### Content Creation
  - Added the ability to load images for planes lazily
  - Added suport for non-uniform static scaling of objects (#1151)
@@ -766,7 +729,7 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Improved the automatic generation of unique names for screen space renderables
  - Added a bookmarks file that will automatically create scene graph nodes to be able to focus on interesting locations
  - Added a new property that makes it possible to disable all mouse input
- 
+
 ### API
  - Fixed retrieval of navigation state from the `openspace.navigation.getNavigationState` function and make this function usable again
  - Added a script that enables to directly add a layder from GIBS `openspace.globebrowsing.addGibsLayer`
@@ -784,7 +747,7 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Added an atmosphere to Venus
  - Added the ability to display procedurally generated text labels and added labels for planetary bodies in the solar system.  The default binding to toggle their visibility is `L`
  - Added the ability to fade satellite trails
- - Added a feature to render stars with a fixed color to make interoperability with Glue easier 
+ - Added a feature to render stars with a fixed color to make interoperability with Glue easier
  - Fixes spelling of layer name for Sea Ice concentration
  - Fixed the milky way by using a static translation to offset it, rather than doing it in the shader code
  - Added missingSun marker in the Osiris-REx scene
@@ -802,7 +765,7 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - No longer assume that the GuiName for a DashboardItem is provided
  - Fixed a bug with the Dawn scene
  - Fixed duplicate keybinds in the rosetta scene
- - Fixed issue with the Mercury magnetosphere 
+ - Fixed issue with the Mercury magnetosphere
  - Added a fix where it was not possible to use a group name in the `getProperty` Lua function
  - Fixed bug in which OpenSpace would crash when an asset includes itself
  - Fixed error when loading some Linux-generated speck files on Windows
@@ -881,8 +844,8 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Replaced Multisampling Antialiasing (MSAA) for a faster Fast Approximate Antialiasing (FXAA) which improves performance and reduced the graphics memory footprint of the application
  - Drastically improved the performance and timing consistency of the Globebrowsing image loading
  - Used the more optimal `setPropertyValueSingle` instead of `setPropertyValue` Lua function in the `propertyHelper.invert` functions, which no longer causes unnecessary RegExp to be compiled
- 
- 
+
+
 # Beta-4 (Patch 1) [0.14.1]
  - Version: 0.14.1
  - Date: 2019-06-04
@@ -998,8 +961,8 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Correctly sort scene items in the Web UI
  - Fixed issues preventing multiple properties from being set simultaneously from a Lua script
  - Fix for bug where the global black-out would not work correctly
- - Only show screenspace renderables on non-UI windows 
- 
+ - Only show screenspace renderables on non-UI windows
+
 ### Optimizations
  - Increased rendering speed of Web UI
  - Slightly improved the rendering speed of globerendering
@@ -1106,12 +1069,12 @@ The team has been working hard on providing a tool to start OpenSpace in distrib
  - Automatically compute a reasonable aspect ratio for custom window sizes
  - Fix issue with commandline arguments not being parsed
  - Fixed rendering issue where the stars would not show up if they are the only Digital Universe object included in the scene
- 
+
 
 # Beta-1 [0.11.0]
   - Version: 0.11.0
   - Date: 2018-01-01
-  - Finished: [6e969794638d7e4761180dc97ca01fb35f356e46](https://github.com/OpenSpace/OpenSpace/commit/6e969794638d7e4761180dc97ca01fb35f356e46) 
+  - Finished: [6e969794638d7e4761180dc97ca01fb35f356e46](https://github.com/OpenSpace/OpenSpace/commit/6e969794638d7e4761180dc97ca01fb35f356e46)
 
 ## Changelog
 ### Content

--- a/docs/general/releases/index.md
+++ b/docs/general/releases/index.md
@@ -1,0 +1,13 @@
+---
+title: Releases
+layout: default
+
+parent: Home
+has_children: true
+nav_order: 1
+---
+
+# Releases
+
+The following pages include an overview of the different OpenSpace releases, user-digestible release notes, explicit changelogs for the varying OpenSpace releases
+

--- a/docs/general/releases/release-notes-0.19.0-release-candidate.md
+++ b/docs/general/releases/release-notes-0.19.0-release-candidate.md
@@ -79,14 +79,14 @@ Please note: The following release notes are incomplete and will be updated as t
  - Update Juno kernels
  - Voyager assets now respects asset.enabled argument when it's passed in asset.require(). Added tags to Voyager models in assets
  - Add option to specify an offset distance for RenderableNodeLine (#2483)
- -  Issue/2408: Moving actions from profiles into assets #2491 
- -  Add actions for minor moons #2476 
+ -  Issue/2408: Moving actions from profiles into assets #2491
+ -  Add actions for minor moons #2476
  - Extended EndTime for Voyager 1 & 2 until 2300 so that trails are visible for longer.
  - Issue/1486: Create labels for all moons
  - Add lighthour grid to DU, and lightminute and lightsecond grids to Earth (closes #2439)
  - Move the Milky Way Image and arm labels from /Universe/Galaxies to /Milky Way
  - Remove luastatemachine example asset, closes #2193
- - Rename ISS scene graph node #2245 
+ - Rename ISS scene graph node #2245
  - Adds labels to the grids (fixes #1244
  - Add trail that co-revolves with L2 around the Sun. Also tweaking the trail colors and speeds in the timelapse script (#2220)
  - Update the Ipac example asset
@@ -155,7 +155,7 @@ Please note: The following release notes are incomplete and will be updated as t
  - No longer trigger an assert when binding a key to an action that does not exist (closes #2485)
  - Properly report an error when an .info file is missing the identifier, preventing the addition of a layer without one (closes #2490)
  - Remove unintentional default value for skybrowser/exoplanet module enabled property (closes #2464)
- -  GUI allows, and crash, when input field has NaN value #2452 
+ -  GUI allows, and crash, when input field has NaN value #2452
  - Fix issue with some action folder sin the Action panel not being clickable #2467
  - Also apply the RenderableTravelSpeed changes to the fadeLength parameter
  - Add special case to the string tokenizer for "Keypad +" (closes #2358)
@@ -186,11 +186,11 @@ Please note: The following release notes are incomplete and will be updated as t
    - Fix bug that channels in cluster don't set the field of view to the same value after animating in SkyBrowser (#2425)
    - Fix bug for screenspace sky browser scale crash (#2280)
    - Skybrowsing: Fix bug when master has no rendering
-   -  SkyBrowser scale sometimes doesn't update the border radius in time #2266 
+   -  SkyBrowser scale sometimes doesn't update the border radius in time #2266
    - SkyBrowser: Ensure browser is initialized properly before executing javascript
    - SkyBrowser: Make it harder to input wrong values
    - SkyBrowser: Fix bug of sending set radius message too early
-   - SkyBrowser: Disable hover circle per default when setting renderable and throw warning if setting to non-existing node (fixes #2153) 
+   - SkyBrowser: Disable hover circle per default when setting renderable and throw warning if setting to non-existing node (fixes #2153)
 
 # Breaking Changes
  - Make the check for whitespaces and dots in identifiers fatal also in non-Debug builds

--- a/docs/general/releases/release-notes/index.md
+++ b/docs/general/releases/release-notes/index.md
@@ -1,0 +1,15 @@
+---
+title: Release Notes
+layout: default
+
+grand_parent: Home
+parent: Releases
+has_children: true
+nav_order: 2
+---
+
+# Release Notes
+
+These pages contain more easily digestible release notes for the major OpenSpace versions.
+
+For a full list of changes, we refer to the [changelog page](./../changelog).

--- a/docs/general/releases/release-notes/v0160.md
+++ b/docs/general/releases/release-notes/v0160.md
@@ -2,14 +2,14 @@
 title: v0.16.0
 layout: default
 
-grand_parent: Users
+grand_parent: Releases
 parent: Release Notes
 nav_order: 4
 ---
 
 # v0.16.0 (Beta-8)
 
-Download v0.16.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version0160) The below notes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release page.](http://wiki.openspaceproject.com/docs/general/releases.html#beta-8)
+Download v0.16.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version0160) The below notes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release changelog page](/docs/general/releases/changelog.html#beta-8).
 
 ## OpenSpace Launcher
 Now you can start up OpenSpace with your scene selection and window configuration without editing the .cfg text file
@@ -26,8 +26,8 @@ The scenes that ship with OpenSpace are defaulted as “Read Only” so they are
 To edit a profile: In the Launcher window, click Edit to choose what will go in the profile. A new window will open, Profile Editor.
 
 Add a Profile Name at the top, and click the Edit button next to each entry to add or remove content and properties (described below)
-  - Once the window is open, click the plus inside the square to expand the category list, and the minus to collapse. 
-  - The column on the right “Enabled” shows what will be included (checkmark) or not (empty square). 
+  - Once the window is open, click the plus inside the square to expand the category list, and the minus to collapse.
+  - The column on the right “Enabled” shows what will be included (checkmark) or not (empty square).
   - Hit save after making changes.
 
 **Properties:** Things that you want to be set automatically when you start up your scene, i.e. if you want all trails off or a certain color to start with. This can be thought of as a keybind that happens on startup.
@@ -35,7 +35,7 @@ Add a Profile Name at the top, and click the Edit button next to each entry to a
   - Use Add New:
     - Put the copied code in Property
     - The Value to set is either true or false
-  - In future, hope this might be selectable from a list.
+  - In the future, hope this might be selectable from a list.
 
 **Assets:** What content is in OpenSpace when you load it
   - This is based on the asset folder (the hierarchical tree i.e. solar system > earth)
@@ -46,8 +46,8 @@ Add a Profile Name at the top, and click the Edit button next to each entry to a
   - You can add in assets with no limit — this means you can add too many things so it will crash OpenSpace based on your computer’s limits, or if the content itself conflicts. In some cases, the log file can be consulted for some errors. If you get a crash and no error message, but think you know what caused the crash, please let us know on Slack or Github.
 
 **Keybindings:** The keyboard shortcuts you want in the profile.
-  - In past, there were multiple steps to set up keybinding: Do what you want to have happen in OpenSpace, go to the script log file (scriptlog.txt in log folder) and copy code, put this code with the key in your keybinding file. 
-  - You still need to do some of these steps: Do what you want the key to do in OpenSpace, copy the code in the log file, then paste using instructions below.
+  - In the past, there were multiple steps to set up keybinding: Do what you want to have happen in OpenSpace, go to the script log file (scriptlog.txt in log folder) and copy code, put this code with the key in your keybinding file.
+  - You still need to do some of these steps: Do what you want the key to do in OpenSpace, copy the code in the log file, then paste using the instructions below.
   - Use Add New:
     - Select the Key Modifier (i.e. Shift) and Key
     - Add a Name
@@ -55,9 +55,9 @@ Add a Profile Name at the top, and click the Edit button next to each entry to a
     - Add a note about what this does in Documentation
     - Paste the code from the log file into Script. You shouldn’t need to edit the quotes in the code, which you sometimes had to do previously. Use a semi-colon in between more than one command.
     - Save this addition, and then the Keybindings window, too
-  - Fro keybindings for Xbox controller, copy your existing script into an asset file instead of this dialogue: OpenSpace/data/assets/util/default_joystick.asset
+  - For keybindings for Xbox controller, copy your existing script into an asset file instead of this dialogue: OpenSpace/data/assets/util/default_joystick.asset
 
-**Meta:** Not currently being used; may be used in the future to share, browse, download profiles.
+**Meta:** Not currently being used; may be used in the future to share, browse, and download profiles.
 
 **Mark Interesting Nodes:** This is what shows up in the Focus menu.
   - To add, you need to know the name of the asset, ie “Earth” “Mars” “ISS” (hope to change this in the future so you can select from available assets)
@@ -73,11 +73,11 @@ Add a Profile Name at the top, and click the Edit button next to each entry to a
     - Anchor is the name of the globe ie Earth or Mars
     - Latitude and Longitude in decimals
     - Altitude is in meters
-  - Navigation State also includes angles — easiest way to do this is to create text file when in OpenSpace, and copy values into this. Enter command in console: openspace.navigation.savecamerastate + a file path
+  - Navigation State also includes angles — the easiest way to do this is to create a text file when in OpenSpace, and copy values into this. Enter command in console: openspace.navigation.savecamerastate + a file path
 
 **Time:** What is the starting time?
   - Default is to start one day ago so Earth has its daily mosaic
-  - You can also set to your current time, by selecting Absolute
+  - You can also set it to your current time, by selecting Absolute
 
 **Modules:** Will not often be used — will be used only if you are building a scene that includes a specific functionality that is not often included in OpenSpace, such as a new module of code that you have written.
 
@@ -88,24 +88,24 @@ In addition to the below, there were performance improvements that should genera
 
 **Asset meta information:** Added meta information (description, author, etc.) that can be accessed in-scene.
   - Access in-scene by clicking question mark in scene menu (to right of the asset name).
-    - This will open a window that has two tabs at the bottom: Description and Info. 
-    - Description: Details what this asset is, with resources listed at the end. 
+    - This will open a window that has two tabs at the bottom: Description and Info.
+    - Description: Details what this asset is, with resources listed at the end.
     - Info: Author(s), version, license, and URL information. Click the scissors to copy this URL to your clipboard.
   - Everything can have meta information, but not everything does right now — it’s a work in progress. Most should have something right now, excluding the missions, which still need to be added.
   - This information is stored in each asset file under and “asset.meta”
 
-**New exoplanets menu:** See [Exoplanets](http://wiki.openspaceproject.com/docs/users/content/exoplanets.html) for detailed overview and instructions.
+**New exoplanets menu:** See [Exoplanets](http://wiki.openspaceproject.com/docs/users/content/exoplanets.html) for a detailed overview and instructions.
 
 **Orion Nebula model:** Added a polygonal Orion Nebula model from Digital Universe Atlas, scaled with World Wide Telescope images.
 
   - The model is “a primitive surface model that shows the elements of the nebula, the proplyds, and the shock fronts.”
-  - See pages 16-17 in the [Digital Universe Atlas Data Profiles guide](https://www.haydenplanetarium.org/downloads/universe/DU-Data-Profiles.pdf) for more. 
+  - See pages 16-17 in the [Digital Universe Atlas Data Profiles guide](https://www.haydenplanetarium.org/downloads/universe/DU-Data-Profiles.pdf) for more.
 
 **Each globebrowsing layer is now its own asset file**
 
   - Previously, there was no easy way to choose what layers are loaded. Now, layers that you don’t use or that are irrelevant can be removed from the menus. There is also meta information for each layer in this file.
   - When building your own profile:
-    - The base asset will use all the default layers. 
+    - The base asset will use all the default layers.
     - There is also a default_layers option for each object.
     - You can select only certain layers by going into the layers in each asset’s hierarchical tree to select which are enabled.
   - The asset files for the layers (both color and height) are in a new folder: data -> assets -> scene -> digitaluniverse or milkyway or solarsystem -> object
@@ -113,7 +113,7 @@ In addition to the below, there were performance improvements that should genera
 
 **New time menu GUI and shortcut to go backward in time**
 
-  - Arrows in the time menu or the keyboard arrow keys can be used to cycle between time increments i.e. from first keybind (1 sec/second) to the next (10 sec/second). 
+  - Arrows in the time menu or the keyboard arrow keys can be used to cycle between time increments i.e. from the first keybind (1 sec/second) to the next (10 sec/second).
   - If using the menu, the current simulation speed will be displayed above the arrows, and the increment if you press the arrows will be written below them.
   - Alt/option + keybind # will do that speed in reverse. For example if “Shift+5” is mapped to a delta time of 30, “Alt+Shift+5” will automatically be bound to -30.
   - Note: Previously, arrow keys were the default keybind to advance slide deck — now the slide deck forward, back, and toggle are defaulted to use the keypad #6, 4, and 0. [See commit #1320.](https://github.com/OpenSpace/OpenSpace/commit/4935ae8814b8812995bc3ceba901579586bb8f3e)
@@ -134,4 +134,4 @@ In addition to the below, there were performance improvements that should genera
 
 **C-Troll:** Application to launch OpenSpace in immersive environments.
 
-  - [C-Troll](www.github.com/c-toolbox/c-troll) is a new, separate application to launch OpenSpace in immersive environments like planetariums. Previously, OpenSpace could be launched in planetariums via existing network structure, Windows file sharing, batch scripts, etc. C-Troll is two applications: Tray application runs on rendering nodes, and C-Troll runs on master node. 
+  - [C-Troll](www.github.com/c-toolbox/c-troll) is a new, separate application to launch OpenSpace in immersive environments like planetariums. Previously, OpenSpace could be launched in planetariums via existing network structure, Windows file sharing, batch scripts, etc. C-Troll is two applications: Tray application runs on rendering nodes, and C-Troll runs on master node.

--- a/docs/general/releases/release-notes/v0161.md
+++ b/docs/general/releases/release-notes/v0161.md
@@ -2,14 +2,14 @@
 title: v0.16.1
 layout: default
 
-grand_parent: Users
+grand_parent: Releases
 parent: Release Notes
 nav_order: 3
 ---
 
 # v0.16.1 (Beta-9)
 
-Download v0.16.1 on the OpenSpace website [installation page.](https://openspaceproject.com/version0161) The below notes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release page](http://wiki.openspaceproject.com/docs/general/releases.html#beta-9).
+Download v0.16.1 on the OpenSpace website [installation page.](https://openspaceproject.com/version0161) The below notes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release changelog page](/docs/general/releases/changelog.html#beta-9).
 
 Though not within the software update, also introduced at this time is the [Hub](http://hub.openspaceproject.com/). Here you will find assets, profiles, and session recordings from the community that you can download and add into OpenSpace. See below for how to use the Import button.
 
@@ -25,7 +25,7 @@ Though not within the software update, also introduced at this time is the [Hub]
 **Import Hub content:** If you visit the new community [Hub](http://hub.openspaceproject.com/) while OpenSpace is running, you can use the Import button to add the asset, profile, or session recording into your current OpenSpace window.
 
 ## Bug fixes
-The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release page](http://wiki.openspaceproject.com/docs/general/releases.html#beta-9).
+The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release changelog page](/docs/general/releases/changelog.html#beta-9).
 
   - Fixed keybinding-related loading errors in New Horizon and Mars profiles
   - Fixed Pioneer model issues and allow SPICE and Horizons versions to coexist

--- a/docs/general/releases/release-notes/v0170.md
+++ b/docs/general/releases/release-notes/v0170.md
@@ -2,27 +2,27 @@
 title: v0.17.0
 layout: default
 
-grand_parent: Users
+grand_parent: Releases
 parent: Release Notes
 nav_order: 2
 ---
 
 # v0.17.0 (Beta-10)
 
-Download v0.17.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version-0170) The below notes about new content, new features, and bug fixes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release page](/docs/general/releases.html#beta-10) and will likely also be of interest to users importing data or customizing OpenSpace.
+Download v0.17.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version-0170) The below notes about new content, new features, and bug fixes are highlights that will be of most interest to OpenSpace users. A complete changelog is available on the [release changelog page](/docs/general/releases/changelog.html#beta-10) and will likely also be of interest to users importing data or customizing OpenSpace.
 
 
 ## New content
 
-**New content for exoplanet systems** 
+**New content for exoplanet systems**
 
-  - Added colored glare to exoplanet stars: The size of the glare scales depending on the stellar radius and stellar temperature in the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu/).  
+  - Added colored glare to exoplanet stars: The size of the glare scales depends on the stellar radius and stellar temperature in the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu/).
   - Added habitable zone for exoplanet systems: This disk is enabled by default after an exoplanet system is added to the scene (read how to do this [here](http://wiki.openspaceproject.com/docs/users/content/exoplanets#adding-exoplanet-systems-to-openspace)). This habitable zone disk has three colors, with red and blue indicating optimistic boundaries and green a conservative boundary where liquid water may be possible. The habitable zone disk was computed using formulas and coefficients by Kopparapu et al (2015) *[Habitable Zones Around Main-Sequence Stars: Dependence on Planetary Mass](https://arxiv.org/abs/1404.5292)*.
   - Added 1 Astronomical Unit (AU) size comparison ring for exoplanet systems and our solar system. This ring allows size comparisons between exoplanet systems and our solar system.
   - For more about the exoplanet module, see the [Exoplanet page](/docs/users/content/exoplanets).
 
 
-**James Webb Space Telescope profile** 
+**James Webb Space Telescope profile**
 
 This profile includes:
   - 3D model of the James Webb Space Telescope
@@ -57,11 +57,11 @@ This profile is based on a 2018 pre-launch planning trajectory by Space Telescop
   - All major 3D model formats
   - Animated models
   - Multitextured models
- 
+
  Many models in OpenSpace have been updated and will have an improved appearance.
 
 
-**Logarithmic sliders:** This makes handling sliders with large values easier to handle. 
+**Logarithmic sliders:** This makes handling sliders with large values easier to handle.
 
 
 **Color picker:** While it has been possible to enter the RGB values for assets with colors (such as trails, labels, Digital Universe datasets) in the Scene menu under Renderable > Appearance, there is now a color picker menu accessed by clicking on the colored square next to the RGB values/sliders. You can select a color using the color sliders, and input HEX, RGB, or HSL values (toggle between these with the up and down arrow next to the values, at the bottom of the color picker).
@@ -70,13 +70,13 @@ This profile is based on a 2018 pre-launch planning trajectory by Space Telescop
 **User folder:** Added one central location for user profiles, assets, screenshots, and config files, which will make it easier to upgrade OpenSpace moving forward.
 
 
-**More obvious shutdown message:** This is to help prevent accidental closing of the application. 
+**More obvious shutdown message:** This is to help prevent accidental closing of the application.
 
 
 **Font size on-screen info text can be adjusted:** The on-screen shutdown, log, friction, and version info text can be made larger or smaller in the openspace.cfg file under FontSize. The dashboard (top left) information can still be adjusted in the Settings menu under Dashboard.
 
 
-**Equirectangular configuration:** Select this configuration at start-up to render or livestream 360 degree videos, such as for YouTube360.
+**Equirectangular configuration:** Select this configuration at start-up to render or livestream 360-degree videos, such as for YouTube360.
 
 
 **Select scripts in profile editor:** You can now choose scripts from the script log to add to your custom profile and when creating keybindings.
@@ -84,7 +84,7 @@ This profile is based on a 2018 pre-launch planning trajectory by Space Telescop
 
 ## Bug fixes
 
-The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release page](http://wiki.openspaceproject.com/docs/general/releases.html#beta-10).
+The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release changelog page](/docs/general/releases/changelog.html#beta-10).
 
   - Mostly eliminated an issue where planets disappear when changing focus
   - Fixed misaligned surface textures for Callisto, Europa, Jupiter, Titan, and Saturn

--- a/docs/general/releases/release-notes/v0180.md
+++ b/docs/general/releases/release-notes/v0180.md
@@ -2,14 +2,14 @@
 title: v0.18.0
 layout: default
 
-grand_parent: Users
+grand_parent: Releases
 parent: Release Notes
 nav_order: 1
 ---
 
 # v0.18.0 (Beta-11)
 
-Download v0.18.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version-0180) Below are notes that highlight new content, features, and bug fixes that will be of most interest to OpenSpace users. A complete changelog is available on the [release page](/docs/general/releases.html#beta-11) and will likely also be of interest to users importing data or customizing OpenSpace.
+Download v0.18.0 on the OpenSpace website [installation page.](https://openspaceproject.com/version-0180) Below are notes that highlight new content, features, and bug fixes that will be of most interest to OpenSpace users. A complete changelog is available on the [release changelog page](/docs/general/changelog.html#beta-11) and will likely also be of interest to users importing data or customizing OpenSpace.
 
 
 ## New content
@@ -19,14 +19,14 @@ Download v0.18.0 on the OpenSpace website [installation page.](https://openspace
   - Added new layers for the Moon, Mars, and Mercury from NASA TREKS
   - Added model-based representations of the Mars moons Phobos and Deimos
   - Added the Starlink satellites and other active satellites
-  - Added a model of the Eiffel tower that can be used for scale references
+  - Added a model of the Eiffel Tower that can be used for scale references
 
 
  **Improvements to existing content**
 
- - Updates to James Webb Space Telescope profile
+ - Updates to the James Webb Space Telescope profile
    - Added a new animated model
-   - Updated timing of launch date to actual launch
+   - Updated timing of launch date to the actual launch
    - Added a [custom webpage](http://ui.openspaceproject.com/jwst_scripts/index.html) to control the orientation of the telescope
  - Updates to Action Panel with new user actions
 
@@ -57,7 +57,7 @@ Download v0.18.0 on the OpenSpace website [installation page.](https://openspace
 
 ## Bug fixes
 
- The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release page](http://wiki.openspaceproject.com/docs/general/releases.html#beta-11).
+ The bug fixes below are of most interest to users. This release includes many more bug fixes, which are listed on the [release page](http://wiki.openspaceproject.com/docs/general/changelog.html#beta-11).
 
  - Fixed issues that would prevent Windows 11 from being detected correctly
  - Prevent a crash when a profile does not provide any Time or Camera information

--- a/docs/general/releases/releases-overview.md
+++ b/docs/general/releases/releases-overview.md
@@ -1,0 +1,48 @@
+---
+title: Overview
+layout: default
+
+grand_parent: Home
+parent: Releases
+nav_order: 1
+---
+
+# Version Overview
+OpenSpace versions are labeled by a version number of the form `MM.mm.rr`,  where `MM` is the major version number, `mm` is the minor version number, and `rr` is the release number (see [Semantic Versioning](https://semver.org)).  In some cases there may be an additional number at the end, `MM.mm.rr.bb`, where bb is the build number, but that will only be for development and testing, not for public release.
+
+As development proceeds, some versions get tagged with names.  This table indicates which version numbers go with which tags, and some notes about each:
+
+| Version | _Name_ | _Date_ | _Description_ |
+| ------- | ------ | ------ | - |
+| 0.18.2 | Beta-11 | 2022-12-24 | This is a second patch release for the eleventh beta release |
+| 0.18.1 | Beta-11 | 2022-11-22 | This is a patch release for the eleventh beta release |
+| 0.18.0 | Beta-11 | 2022-05-06 | This is the eleventh beta release and the first in 2022 |
+| 0.17.2 | Beta-10 | 2021-08-27 | This is a patch release for the tenth beta that addresses an issue with Earth terrain |
+| 0.17.1 | Beta-10 | 2021-08-09 | This is a patch release for the tenth beta that addresses initial bug reports |
+| 0.17.0 | Beta-10 | 2021-07-14 | This is the tenth beta release and the second in 2021 |
+| 0.16.1 | Beta-9 | 2021-05-07 | This is the ninth beta release and the first in 2021 |
+| 0.16.0 | Beta-8 | 2020-12-09 | This is the eigth beta release for the end of 2020 |
+| 0.15.2 | Beta-7 | 2020-06-26 | This is the seventh beta release for OpenSpace for the summer of 2020 |
+| 0.15.1 | Beta-6 | 2020-02-17 | This is the sixth beta release for OpenSpace in conjunction with the 4th annual developer's meeting |
+| 0.15.0 | Beta-5 | 2019-09-17 | This is the fifth beta release for OpenSpace released on September, 17th, 2019 for the ASTC conference |
+| 0.14.1 | Beta-4 | 2019-06-04 | This is the first patch release for the fourth beta |
+| 0.14.0 | Beta-4 | 2019-05-20 | This is the fourth beta release for OpenSpace released on the 20th of May, 2019 |
+| 0.13.0 | Beta-3 | 2018-11-05 | This is the third beta release for OpenSpace released on the 5th of November, 2018 |
+| 0.12.0 | Beta-2 | 2018-07-11 | This is the second beta release for OpenSpace released on the 11th July 2018 in the aftermath of IPS in Toulouse, France. |
+| 0.11.1 | Beta-1 | 2018-02-13 | This is a patch release for the beta-1 version released on January 1st, 2018. It mainly fixes bugs and issues that have come up for users with the beta-1 release of OpenSpace. |
+| 0.11.0 | Beta-1 | 2018-01-01 | This is the first beta release for OpenSpace released on January 1st, 2018. It contains all of the previously released features + new content and feature updates. |
+| 0.10.0 | Prerelease-15 | 2017-10-24 | This prerelease is a collection of features that have been developed since the last public prerelease version for release at the Association of Science – Technology Centers (ASTC) conference. |
+| 0.9.0 | Prerelease-14 | 2017-07-21 | This prerelease is a collection of features that have been developed since the last public prerelease version. |
+| 0.8.0 | Prerelease-13 | 2017-04-18 | Prerelease for the Earth Day 2017 |
+| 0.7.0 | Prerelease-12 | 2016-02-19 | NAOJ presentation |
+| 0.6.0 | Prerelease-11 | 2016-12-14 | AGU presentation |
+| 0.5.0 | Prerelease-10 | 2016-09-25 | Norrköping's Kulturnatten presentation |
+| 0.4.0 | Prerelease-9 | 2016-07-11 | This pre-release version was prepared for a meeting at the AMNH of the ISI User Network. |
+| 0.3.4 | Prerelease-8 | 2016-06-22 | IPS exhibition |
+| 0.3.3 | Prerelease-8 | 2016-06-07 | EuroVis presentation |
+| 0.3.2 | Prerelease-8 | 2016-04-15 | CCMC Show |
+| 0.3.1 | Prerelease-8 | 2016-03-03 | New Horizons Show |
+| 0.3.0 | Prerelease-8 | 2015-07-16 | |
+| 0.2.1 | Prerelease-7 | 2015-07-15 | New Horizons Show |
+| 0.2.0 | Prerelease-7 | 2015-07-08 | This prerelease was published for a global, networked event in celebration of New Horizon’s closest approach to Pluto. |
+| 0.1.0 | Prerelease-5 | 2015-05-14 | This prerelease was published for the Pluto-Palooza event held at the AMNH in New York. |

--- a/docs/users/commandline.md
+++ b/docs/users/commandline.md
@@ -3,7 +3,7 @@ title: Using the Commandline
 layout: default
 
 parent: Users
-nav_order: 4
+nav_order: 3
 ---
 
 This wiki covers the use of the OpenSpace console, which allows precise details of a scene to be accessed or controlled.  The console is an advanced tool, and a basic understanding of OpenSpace properties and namespaces is recommended before using it.

--- a/docs/users/content/index.md
+++ b/docs/users/content/index.md
@@ -5,7 +5,7 @@ layout: default
 parent: Users
 has_children: true
 has_toc: false
-nav_order: 4
+nav_order: 3
 ---
 
 # Content

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -3,7 +3,7 @@ title: Frequenty Asked Questions
 layout: default
 
 parent: Users
-nav_order: 7
+nav_order: 6
 ---
 
 # Linux

--- a/docs/users/globebrowsing/index.md
+++ b/docs/users/globebrowsing/index.md
@@ -4,5 +4,5 @@ layout: default
 
 parent: Users
 has_children: true
-nav_order: 5
+nav_order: 4
 ---

--- a/docs/users/kiosk.md
+++ b/docs/users/kiosk.md
@@ -3,7 +3,7 @@ title: Kiosk Touch-Screen Version
 layout: default
 
 parent: Users
-nav_order: 6
+nav_order: 5
 ---
 
 # Story Selection

--- a/docs/users/navigation/general.md
+++ b/docs/users/navigation/general.md
@@ -5,7 +5,7 @@ layout: default
 parent: Users
 has_children: true
 has_toc: false
-nav_order: 3
+nav_order: 2
 ---
 
 Pages covering navigation in space and time

--- a/docs/users/release-notes/index.md
+++ b/docs/users/release-notes/index.md
@@ -1,8 +1,0 @@
----
-title: Release Notes
-layout: default
-
-parent: Users
-has_children: true
-nav_order: 2
----


### PR DESCRIPTION
Makes it easier to maintain for us, and to browse and navigate for users. The "Release Notes" is moved from the Users section into the releases section and the changelog page is split up into two, to be a bit less overwhelming.

OBS! Note that with this (if accepted), the OpenSpaceproject.com installation pages also have to be updated, as they include links to the old page locations. E.g.: https://www.openspaceproject.com/beta-version-0182
@meganvilla 

Some screenshots of the new page structure

Landing page
![image](https://github.com/OpenSpace/openspace.github.io/assets/8808894/60366e0c-1a0c-46b9-a1cc-b410b8190d40)

Overview
![image](https://github.com/OpenSpace/openspace.github.io/assets/8808894/5c3ced26-bf3f-4dcc-95d3-1f486990527f)

Release Notes
![image](https://github.com/OpenSpace/openspace.github.io/assets/8808894/50778f8c-8e29-4b42-b29f-7c65525464fb)

Changelog
![image](https://github.com/OpenSpace/openspace.github.io/assets/8808894/a089bc84-cd83-4df7-ab21-47799741cdf7)
